### PR TITLE
CI: Fix R version specification

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          r-version: ${{ matrix.config.r }}
 
       - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
 
       - name: Install system dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
The R version should be specified for r-lib/actions/setup-r, not actions/checkout.
This moves the with item to the right step.
