### PR TITLE
Calibrate print

### DIFF
--- a/R/calibrate.R
+++ b/R/calibrate.R
@@ -568,18 +568,25 @@ calibrate <- function(infected_years_file,
           config$proposed_particles <- config$proposed_particles + 1
         }
         acceptance_rate <- config$current_particles / config$proposed_particles
-        acceptance_rate_info <-
-          paste("generation:", config$current_bin,
-                "particle:", config$current_particles,
-                "acceptance rate:", acceptance_rate,
-                "location difference (c1):", location_difference,
-                "distance difference (c2):", distance_difference,
-                "residual difference (c3):", residual_difference,
-                "number infected difference (c4):",
-                number_infected_difference,
-                sep = " ")
+        acceptance_rate_info <- paste(
+                            "generation:                     ",
+                            config$current_bin,
+                            "\nparticle:                       ",
+                            config$current_particles,
+                            "\nacceptance rate:                ",
+                            format(acceptance_rate, digits = 5),
+                            "\nlocation difference (c1):       ",
+                            location_difference,
+                            "\ndistance difference (c2):       ",
+                            distance_difference,
+                            "\nresidual difference (c3):       ",
+                            residual_difference,
+                            "\nnumber infected difference (c4):",
+                            number_infected_difference,
+                            "\n\n",
+                            sep = " ")
         if (verbose) {
-          print(acceptance_rate_info)
+          cat(acceptance_rate_info)
         }
       }
 

--- a/R/calibrate.R
+++ b/R/calibrate.R
@@ -141,7 +141,7 @@ calibrate <- function(infected_years_file,
                       calibration_method = "ABC",
                       number_of_iterations = 100000,
                       exposed_file = "",
-                      verbose = FALSE) {
+                      verbose = TRUE) {
 
   # add all data to config list
   config <- c()

--- a/man/calibrate.Rd
+++ b/man/calibrate.Rd
@@ -66,7 +66,7 @@ calibrate(
   calibration_method = "ABC",
   number_of_iterations = 1e+05,
   exposed_file = "",
-  verbose = FALSE
+  verbose = TRUE
 )
 }
 \arguments{
@@ -285,7 +285,6 @@ preferably 1 million).}
 \item{verbose}{Boolean with true printing current status of calibration,
 (e.g. the current generation, current particle, and the acceptance rate).
 Defaults if FALSE.}
-
 }
 \value{
 a dataframe of the variables saved and their success metrics for


### PR DESCRIPTION
formatting of calibration print to multi-line output. Change print to cat to use line breaks. set verbose to true by default to match previous expected behavior.