### PR TITLE
Add final_step as valid option in configuration checks

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -200,7 +200,7 @@ time_checks <- function(end_date, start_date, time_step,
   }
 
   if (checks_passed && !(output_frequency %in% list(
-    "week", "month", "day", "year", "time_step", "every_n_steps"
+    "week", "month", "day", "year", "time_step", "every_n_steps", "final_step"
   ))) {
     checks_passed <- FALSE
     failed_check <- output_type_error


### PR DESCRIPTION
`output_frequency = "final_step"` is currently not accepted as valid option, although the model supports it.